### PR TITLE
Individual GPU Hashrate

### DIFF
--- a/foreman-claymore/src/main/java/mn/foreman/claymore/Claymore.java
+++ b/foreman-claymore/src/main/java/mn/foreman/claymore/Claymore.java
@@ -107,12 +107,26 @@ public class Claymore
         final String ethTotalShares = ethRateAndShares[1];
         final String ethRejectedShares = ethRateAndShares[2];
 
-        final int numGpus = results.get(3).split(";").length;
+        final String[] ethGpuRates = results.get(3).split(";");
+        final int numGpus = ethGpuRates.length;
+        final List<String> ethGpuHashRate = new LinkedList<>();
+        for (int i = 0; i < numGpus; i++) {
+            ethGpuHashRate.add(ethGpuRates[i]);
+        }
 
         final String[] dcrRateAndShares = results.get(4).split(";");
         final String dcrHashRate = dcrRateAndShares[0];
         final String dcrTotalShares = dcrRateAndShares[1];
         final String dcrRejectedShares = dcrRateAndShares[2];
+        
+        final String[] dcrGpuRates = results.get(5).split(";");
+        final List<String> dcrGpuHashRate = new LinkedList<>();
+        for (int i = 0; i < numGpus; i++) {
+            if(dcrGpuRates[i].equals("off"))
+            	dcrGpuHashRate.add("0");
+            else
+            	dcrGpuHashRate.add(dcrGpuRates[i]);
+        }
 
         final List<String> temps = new LinkedList<>();
         final List<String> fans = new LinkedList<>();
@@ -139,6 +153,7 @@ public class Claymore
                 results.get(0),
                 ethHashRate,
                 numGpus,
+                ethGpuHashRate,
                 temps,
                 fans,
                 statsBuilder);
@@ -146,6 +161,7 @@ public class Claymore
                 results.get(0),
                 dcrHashRate,
                 numGpus,
+                dcrGpuHashRate,
                 temps,
                 fans,
                 statsBuilder);
@@ -222,12 +238,13 @@ public class Claymore
     /**
      * Adds a {@link Rig} using the provided parameters.
      *
-     * @param identifier The identifier.
-     * @param hashRate   The hash rate.
-     * @param numGpus    The number of GPUs.
-     * @param temps      The temperatures.
-     * @param fans       The fans.
-     * @param builder    The builder to update.
+     * @param identifier  The identifier.
+     * @param hashRate    The hash rate.
+     * @param numGpus     The number of GPUs.
+     * @param gpuHashRate The hash rate of GPUs.
+     * @param temps       The temperatures.
+     * @param fans        The fans.
+     * @param builder     The builder to update.
      *
      * @throws MinerException on failure to identify the Claymore type.
      */
@@ -235,6 +252,7 @@ public class Claymore
             final String identifier,
             final String hashRate,
             final int numGpus,
+            final List<String> gpuHashRate,
             final List<String> temps,
             final List<String> fans,
             final MinerStats.Builder builder) throws MinerException {
@@ -256,6 +274,7 @@ public class Claymore
                                         .setIndex(Integer.toString(i))
                                         // Bus is not exposed in claymore
                                         .setBus("0")
+                                        .setHashRate(new BigDecimal(Iterables.get(gpuHashRate, i, "0")).multiply(multiplier))
                                         .setTemp(Iterables.get(temps, i, "0"))
                                         .setFans(
                                                 new FanInfo.Builder()

--- a/foreman-claymore/src/test/java/mn/foreman/claymore/PhoenixITest.java
+++ b/foreman-claymore/src/test/java/mn/foreman/claymore/PhoenixITest.java
@@ -58,6 +58,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 0")
+                                                        .setHashRate(new BigDecimal("29792000"))
                                                         .setTemp(50)
                                                         .setIndex(0)
                                                         .setBus(0)
@@ -76,6 +77,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 1")
+                                                        .setHashRate(new BigDecimal("29791000"))
                                                         .setTemp(46)
                                                         .setIndex(1)
                                                         .setBus(0)
@@ -94,6 +96,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 2")
+                                                        .setHashRate(new BigDecimal("29689000"))
                                                         .setTemp(47)
                                                         .setIndex(2)
                                                         .setBus(0)
@@ -112,6 +115,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 3")
+                                                        .setHashRate(new BigDecimal("29787000"))
                                                         .setTemp(47)
                                                         .setIndex(3)
                                                         .setBus(0)
@@ -130,6 +134,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 4")
+                                                        .setHashRate(new BigDecimal("29793000"))
                                                         .setTemp(48)
                                                         .setIndex(4)
                                                         .setBus(0)
@@ -148,6 +153,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 5")
+                                                        .setHashRate(new BigDecimal("29794000"))
                                                         .setTemp(48)
                                                         .setIndex(5)
                                                         .setBus(0)
@@ -166,6 +172,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 6")
+                                                        .setHashRate(new BigDecimal("29793000"))
                                                         .setTemp(47)
                                                         .setIndex(6)
                                                         .setBus(0)
@@ -184,6 +191,7 @@ public class PhoenixITest
                                         .addGpu(
                                                 new Gpu.Builder()
                                                         .setName("GPU 7")
+                                                        .setHashRate(new BigDecimal("29494000"))
                                                         .setTemp(48)
                                                         .setIndex(7)
                                                         .setBus(0)

--- a/foreman-innosilicon/pom.xml
+++ b/foreman-innosilicon/pom.xml
@@ -39,12 +39,12 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>mn.foreman</groupId>
-            <artifactId>foreman-dragonmint</artifactId>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-        </dependency>
+<!--         <dependency> -->
+<!--             <groupId>mn.foreman</groupId> -->
+<!--             <artifactId>foreman-dragonmint</artifactId> -->
+<!--             <scope>test</scope> -->
+<!--             <classifier>tests</classifier> -->
+<!--         </dependency> -->
         <dependency>
             <groupId>mn.foreman</groupId>
             <artifactId>foreman-util</artifactId>

--- a/foreman-model/src/main/java/mn/foreman/model/miners/rig/Gpu.java
+++ b/foreman-model/src/main/java/mn/foreman/model/miners/rig/Gpu.java
@@ -1,15 +1,23 @@
 package mn.foreman.model.miners.rig;
 
 import mn.foreman.model.AbstractBuilder;
+import mn.foreman.model.miners.BigDecimalSerializer;
 import mn.foreman.model.miners.FanInfo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.math.BigDecimal;
+
 /** A {@link Gpu} represents a single GPU in a {@link Rig}. */
 public class Gpu {
+
+    /** The hash rate. */
+    @JsonSerialize(using = BigDecimalSerializer.class)
+    private final BigDecimal hashRate;
 
     /** The bus index. */
     private final int bus;
@@ -32,6 +40,7 @@ public class Gpu {
     /**
      * Constructor.
      *
+     * @param hashRate The hash rate.
      * @param name     The name.
      * @param bus      The bus.
      * @param fans     The fans.
@@ -40,12 +49,16 @@ public class Gpu {
      * @param temp     The temp.
      */
     private Gpu(
+            @JsonProperty("hashRate") final BigDecimal hashRate,
             @JsonProperty("bus") final int bus,
             @JsonProperty("fans") final FanInfo fans,
             @JsonProperty("freqInfo") final FreqInfo freqInfo,
             @JsonProperty("index") final int index,
             @JsonProperty("name") final String name,
             @JsonProperty("temp") final int temp) {
+        Validate.notNull(
+                hashRate,
+                "Speed cannot be null");
         Validate.isTrue(
                 bus >= 0,
                 "Bus must be >= 0");
@@ -64,6 +77,7 @@ public class Gpu {
         Validate.notEmpty(
                 name,
                 "Name cannot be empty");
+        this.hashRate = hashRate;
         this.bus = bus;
         this.fans = fans;
         this.freqInfo = freqInfo;
@@ -83,6 +97,7 @@ public class Gpu {
             final Gpu gpu = (Gpu) other;
             isEqual =
                     new EqualsBuilder()
+                            .append(this.hashRate, gpu.hashRate)
                             .append(this.bus, gpu.bus)
                             .append(this.fans, gpu.fans)
                             .append(this.freqInfo, gpu.freqInfo)
@@ -92,6 +107,15 @@ public class Gpu {
                             .isEquals();
         }
         return isEqual;
+    }
+
+    /**
+     * Returns the hash rate.
+     *
+     * @return The hash rate.
+     */
+    public BigDecimal getHashRate() {
+        return this.hashRate;
     }
 
     /**
@@ -151,6 +175,7 @@ public class Gpu {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
+                .append(this.hashRate)
                 .append(this.bus)
                 .append(this.fans)
                 .append(this.freqInfo)
@@ -164,6 +189,7 @@ public class Gpu {
     public String toString() {
         return String.format(
                 "%s [ " +
+                        "hashRate=%s, " +
                         "bus=%s, " +
                         "fans=%s, " +
                         "freqInfo=%s, " +
@@ -172,6 +198,7 @@ public class Gpu {
                         "temp=%s" +
                         " ]",
                 getClass().getSimpleName(),
+                this.hashRate,
                 this.bus,
                 this.fans,
                 this.freqInfo,
@@ -183,6 +210,9 @@ public class Gpu {
     /** A builder for creating {@link Gpu GPUs}. */
     public static class Builder
             extends AbstractBuilder<Gpu> {
+
+        /** The speed info. */
+        private BigDecimal hashRate;
 
         /** The bus separator. */
         private static final String BUS_SEPARATOR = ":";
@@ -208,12 +238,25 @@ public class Gpu {
         @Override
         public Gpu build() {
             return new Gpu(
+                    this.hashRate,
                     this.bus,
                     this.fans,
                     this.freqInfo,
                     this.index,
                     this.name,
                     this.temp);
+        }
+
+        /**
+         * Sets the hash rate.
+         *
+         * @param hashRate The hash rate.
+         *
+         * @return This builder instance.
+         */
+        public Builder setHashRate(final BigDecimal hashRate) {
+            this.hashRate = hashRate;
+            return this;
         }
 
         /**

--- a/foreman-sgminer/src/main/java/mn/foreman/sgminer/response/DevsResponseStrategy.java
+++ b/foreman-sgminer/src/main/java/mn/foreman/sgminer/response/DevsResponseStrategy.java
@@ -100,10 +100,13 @@ public class DevsResponseStrategy
             rate = map.get(MHS_5_KEY);
         } else if (map.containsKey(MHS_30_KEY)) {
             rate = map.get(MHS_30_KEY);
-        } else {
+        } else if (map.containsKey(MHS_AV_KEY)) {
             rate = map.get(MHS_AV_KEY);
+        } else {
+            rate = "0.0";
         }
-        return new BigDecimal(rate);
+        return new BigDecimal(rate).multiply(
+                new BigDecimal(1000 * 1000));
     }
 
     /**
@@ -133,6 +136,7 @@ public class DevsResponseStrategy
                 .setName("GPU " + values.get("GPU"))
                 .setIndex(values.get("GPU"))
                 .setBus(0)
+                .setHashRate(getRate(values))
                 .setTemp(values.get("Temperature"))
                 .setFans(
                         new FanInfo.Builder()
@@ -160,9 +164,6 @@ public class DevsResponseStrategy
         return values
                 .stream()
                 .map(DevsResponseStrategy::getRate)
-                .map((value) ->
-                        value.multiply(
-                                new BigDecimal(1000 * 1000)))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/foreman-sgminer/src/test/java/mn/foreman/sgminer/TeamRedMiner_0_3_10_ITest.java
+++ b/foreman-sgminer/src/test/java/mn/foreman/sgminer/TeamRedMiner_0_3_10_ITest.java
@@ -157,6 +157,7 @@ public class TeamRedMiner_0_3_10_ITest
                                                         .setName("GPU 0")
                                                         .setIndex(0)
                                                         .setBus(0)
+                                                        .setHashRate(new BigDecimal("1794000.000"))
                                                         .setTemp(69)
                                                         .setFans(
                                                                 new FanInfo.Builder()

--- a/foreman-trex/src/main/java/mn/foreman/trex/TrexJson.java
+++ b/foreman-trex/src/main/java/mn/foreman/trex/TrexJson.java
@@ -122,6 +122,7 @@ public class TrexJson
                                 ((gpu.name != null) && (!StringUtils.isBlank(gpu.name)))
                                         ? gpu.name
                                         : "GPU " + gpu.deviceId)
+                        .setHashRate(gpu.hashRate)
                         .setTemp(gpu.temperature)
                         .setFreqInfo(
                                 new FreqInfo.Builder()

--- a/foreman-trex/src/main/java/mn/foreman/trex/json/Summary.java
+++ b/foreman-trex/src/main/java/mn/foreman/trex/json/Summary.java
@@ -291,6 +291,10 @@ public class Summary {
         @JsonProperty("device_id")
         public int deviceId;
 
+        /** The hash rate. */
+        @JsonProperty("hashrate")
+        public BigDecimal hashRate;
+
         /** The fan speed. */
         @JsonProperty("fan_speed")
         public int fanSpeed;

--- a/foreman-trex/src/test/java/mn/foreman/trex/Api3_0TrexITest.java
+++ b/foreman-trex/src/test/java/mn/foreman/trex/Api3_0TrexITest.java
@@ -96,6 +96,7 @@ public class Api3_0TrexITest
                                                         .setIndex(0)
                                                         .setBus(0)
                                                         .setName("GeForce GTX 1050 Ti")
+                                                        .setHashRate(new BigDecimal(7748158))
                                                         .setTemp(68)
                                                         .setFans(
                                                                 new FanInfo.Builder()


### PR DESCRIPTION
 - Added BigDecimal HashRate to Gpu model
 - Added gpu hashrate support and tests for 
    - SGminer
       - Mhs to Hs converstion moved from toRate() to getRate()
    - Claymore 
       - Added gpu hr parsing for eth and dcr response
    - Trex
       - Added gpu.hashrate to summary model
 -  Removed foreman-dragonmint(test) dependency from foreman-innosilicon artifact